### PR TITLE
[fix][offload] Break the fillbuffer loop when met EOF

### DIFF
--- a/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamImpl.java
@@ -107,9 +107,7 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
                     bufferOffsetEnd = endRange;
                     long bytesRead = endRange - startRange + 1;
                     int bytesToCopy = (int) bytesRead;
-                    while (bytesToCopy > 0) {
-                        bytesToCopy -= buffer.writeBytes(stream, bytesToCopy);
-                    }
+                    fillBuffer(stream, bytesToCopy);
                     cursor += buffer.readableBytes();
                 }
 
@@ -133,6 +131,20 @@ public class BlobStoreBackedInputStreamImpl extends BackedInputStream {
             }
         }
         return true;
+    }
+
+    void fillBuffer(InputStream is, int bytesToCopy) throws IOException {
+        while (bytesToCopy > 0) {
+            int writeBytes = buffer.writeBytes(is, bytesToCopy);
+            if (writeBytes < 0) {
+                break;
+            }
+            bytesToCopy -= writeBytes;
+        }
+    }
+
+    ByteBuf getBuffer() {
+        return buffer;
     }
 
     @Override

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreBackedInputStreamTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.offload.jcloud.impl;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.bookkeeper.mledger.offload.jcloud.BlobStoreTestBase;
+import org.testng.annotations.Test;
+
+public class BlobStoreBackedInputStreamTest extends BlobStoreTestBase {
+
+    @Test
+    public void testFillBuffer() throws Exception {
+        BlobStoreBackedInputStreamImpl bis = new BlobStoreBackedInputStreamImpl(
+            blobStore, BUCKET, "testFillBuffer", (k, md) -> {
+        }, 2048, 512);
+
+        InputStream is = new InputStream() {
+            int count = 10;
+
+            @Override
+            public int read() throws IOException {
+                if (count-- > 0) {
+                    return 1;
+                } else {
+                    return -1;
+                }
+            }
+        };
+        bis.fillBuffer(is, 20);
+        assertEquals(bis.getBuffer().readableBytes(), 10);
+    }
+}


### PR DESCRIPTION
---

### Motivation

When hit an EOF, the write bytes will return -1 then it would make the bytesToCoppy bigger than the buffer to fill. Then we will hit the java.lang.IndexOutOfBoundsException.
Break the look when hit the EOF, fill the buffer next time.

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
